### PR TITLE
Integrate search tab into main window with Stack navigation and shared SearchService

### DIFF
--- a/src/ui/components/search_view.rs
+++ b/src/ui/components/search_view.rs
@@ -41,6 +41,10 @@ pub struct SearchView {
 
 impl SearchView {
     pub fn new() -> Self {
+        Self::new_with_service(SearchService::new(10))
+    }
+
+    pub fn new_with_service(search_service: SearchService) -> Self {
         let container = gtk4::Box::new(Orientation::Vertical, 12);
         container.set_margin_top(12);
         container.set_margin_bottom(12);
@@ -87,7 +91,6 @@ impl SearchView {
         container.append(&status_label);
         container.append(&scrolled_window);
 
-        let search_service = SearchService::new(10);
         let thumbnail_cache = Rc::new(RefCell::new(HashMap::new()));
         let download_callback = Rc::new(RefCell::new(None));
 


### PR DESCRIPTION
### Summary
This update embeds the search UI into the main window by introducing a two-tab interface (Download/Search) and a shared SearchService instance.

### Details
- Added a GTK Stack with a header-based StackSwitcher to toggle between Download and Search.
- Exposed two pages: the existing Download form and a new SearchView instance fed with a single SearchService.
- Search results can populate the Download URL and optionally trigger the download flow, reusing existing logic.
- Maintains consistent status, progress, and overwrite state across tab switches.
- Updated UI text to guide users through searching and downloading seamlessly.